### PR TITLE
Add support for border watermarks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ author = 'Brian Moss'
 # built documents.
 #
 # The short X.Y version.
-version = '0.1.11'
+version = '0.1.12'
 # The full version, including alpha/beta/rc tags.
 # release = 'beta'
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -83,12 +83,35 @@ sphinxmark_div (string)
 
      openstackdocstheme -> ``sphinxmark_div = 'docs-body'``
 
+sphinxmark_border (string)
+   - ``left`` - place watermark on left border
+   - ``right`` - place watermark on right border
+   - setting the ``sphinxmark_border`` option overrides the
+     ``sphinxmark_repeat`` and ``sphinxmark_fixed`` options.
+   - when using a text watermark, adjust the ``sphinxmark_text`` options
+     to achieve the desired appearance.
+   - Default = None
+   - Example:
+
+     ``sphinxmark_border = 'left'``
+
 sphinxmark_repeat (bool)
    - ``True`` - image repeats down the page
    - ``False`` - image appears once at top of page
    - Default = True
+   - Example:
 
-      ``sphinxmark_repeat = True``
+     ``sphinxmark_repeat = True``
+
+sphinxmark_fixed (bool)
+   - ``True`` - watermark does not scroll with content
+   - ``False`` - watermark scrolls with content
+   - This option centers the watermark in the viewport, not the div
+     specified by ``sphinxmark_div``.
+   - Default = False
+   - Example:
+
+     ``sphinxmark_fixed = False``
 
 sphinxmark_image (string)
    - image file in ``html_static_path`` directory to use as watermark
@@ -138,6 +161,12 @@ sphinxmark_text_spacing (int)
 
       ``sphinxmark_text_spacing = 400``
 
+sphinxmark_text_rotation (int)
+   - Text watermark rotation
+   - Default = 0
+   - Example:
+
+     ``sphinxmark_text_rotation = 90``
 
 Troubleshooting
 ~~~~~~~~~~~~~~~

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -1,3 +1,4 @@
 css
 png
 sphinxmark
+viewport

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='sphinxmark',
-    version='0.1.11',
+    version='0.1.12',
     description='A Sphinx extension that enables watermarks for HTML output.',
     long_description=long_description,
     url='https://github.com/kallimachos/sphinxmark',
@@ -40,7 +40,8 @@ setup(
     packages=['sphinxmark'],
 
     package_data={
-        'sphinxmark': ['watermark-draft.png', 'watermark.tpl', 'arial.ttf'],
+        'sphinxmark': ['watermark-draft.png', 'border.tpl',
+                       'watermark.tpl', 'arial.ttf'],
     },
 
     install_requires=['bottle', 'Pillow'],

--- a/sphinxmark/border.tpl
+++ b/sphinxmark/border.tpl
@@ -1,0 +1,7 @@
+div.{{div}} {
+    border-{{side}}: 100px solid transparent;
+    padding: 15px;
+    -webkit-border-image: url({{image}}) 20% round;
+    -o-border-image: url({{image}}) 20% round;
+    border-image: url({{image}}) 20% 100% repeat;
+}

--- a/sphinxmark/watermark.tpl
+++ b/sphinxmark/watermark.tpl
@@ -1,5 +1,6 @@
 div.{{div}} {
-  background-image: url("{{ image }}") !important;
-  background-repeat: {{ repeat }} !important;
-  background-position: center top !important;
-  }
+  background-image: url("{{image}}") !important;
+  background-repeat: {{repeat}} !important;
+  background-position: {{position}} top !important;
+  background-attachment: {{attachment}} !important;
+}

--- a/tests/marktest/conf.py
+++ b/tests/marktest/conf.py
@@ -62,11 +62,14 @@ htmlhelp_basename = 'testmarkdoc'
 
 # Options for sphinxmark
 sphinxmark_enable = True
-# sphinxmark_div = 'default'
-# sphinxmark_repeat = True
-# sphinxmark_image = 'default'
-# sphinxmark_text = 'default'
+# sphinxmark_div = 'docs-body'
+# sphinxmark_border = 'left'
+# sphinxmark_repeat = False
+# sphinxmark_fixed = True
+# sphinxmark_image = 'text'
+# sphinxmark_text = 'Mitaka'
 # sphinxmark_text_color = (255, 0, 0)
 # sphinxmark_text_size = 100
-# sphinxmark_text_opacity = 20
-# sphinxmark_text_spacing = 400
+# sphinxmark_text_opacity = 50
+# sphinxmark_text_spacing = 600
+# sphinxmark_text_rotation = 90

--- a/tests/marktest/index.rst
+++ b/tests/marktest/index.rst
@@ -20,54 +20,55 @@ Usage
 
 #. Install sphinxmark:
 
-   .. code::
-
-      $ pip install sphinxmark
+   ``$ pip install sphinxmark``
 
 #. Open ``conf.py`` and import sphinxmark:
 
-   .. code::
-
-      import sphinxmark
+   ``import sphinxmark``
 
 #. Add watermark to the list of extensions in ``conf.py``:
 
-   .. code::
-
-      extensions = [
-         'sphinx.ext.autodoc',
-         'sphinx.ext.doctest',
-         'sphinxmark',
-      ]
+   ``extensions = ['sphinxmark']``
 
 #. Specify a static directory in ``conf.py`` for your watermark files. If the
    path does not exist, the watermark extension creates the directory and
    populates it with ``watermark.css`` and ``watermark-draft.png``:
 
-   .. code::
-
-      html_static_path = ['_static']
-
-   .. note::
-
-      ``watermark.css`` is recreated on each Sphinx run. Edits to this file
-      are not retained.
+   ``html_static_path = ['_static']``
 
 #. Configure watermark in ``conf.py`` as required:
 
-   .. code::
-
-      watermark_enable = True
-      watermark_image = 'default'
-      watermark_debug = False
+   ``watermark_enable = True``
 
 #. Put images in your static directory and edit ``watermark_image``
    to use custom watermarks.
 
 
-.. important::
+More paragraphs
+~~~~~~~~~~~~~~~
 
-   The extension provides a template css file that uses the specified image
-   as the watermark for any area defined as ``div.body``. Watermark will not
-   work with themes that do not place body content in ``div.body``. For this
-   reason, watermark does not work with ``sphinx_rtd_theme``.
+Lorem ipsum dolor sit amet, per te enim fabulas invidunt, electram vulputate
+cotidieque an has. Mei pericula maluisset concludaturque id, hinc quaeque
+ullamcorper ei eam. Ius ne quot nihil iriure, legere alterum in cum. Cu sit
+error altera eligendi, an omnes sapientem eam. Ipsum aeque in cum. Eum habeo
+tacimates ut.
+
+Ex dolorem temporibus ius. Ad commodo repudiare evertitur eam, eirmod labores
+an cum. Ne lorem affert vel, atqui omnes complectitur his et. Ex pri elitr
+deleniti concludaturque, te nam choro molestie necessitatibus.
+
+Eu vis eius aliquid. Idque quidam mea at, mea eu inani dolorum consequuntur.
+Dolore scribentur est eu, pro in suas aperiam consequat, tale molestie
+urbanitas ei ius. Ea mollis suscipiantur nec, qui cu delenit perfecto, sea
+prima sonet soleat ad. Nam ea wisi recusabo, eu probo legimus vim.
+
+Ea vero constituam vix. Cum at aliquip vituperatoribus. Ius enim simul ne, mel
+ad tantas consectetuer. Debitis delectus percipitur has no, quo ad eius eripuit
+mandamus. Ne quaeque disputationi his.
+
+Tollit mentitum vituperatoribus sea at. Cu his dicam voluptua temporibus, id
+usu modus regione. Ea saperet principes abhorreant has, audiam denique
+dissentiunt in eos. Te paulo soleat vituperatoribus pro, ut veri ridens vis.
+Mei modus deleniti eleifend eu, veri maiorum oportere at ius, in diam facilis
+nusquam ius. Ea noster omnesque recusabo mei, te utamur commune omnesque pri,
+pro ei fabellas lucilius torquatos.

--- a/tests/test.py
+++ b/tests/test.py
@@ -9,13 +9,16 @@ xfail = mark.xfail
 
 # defaults = {'sphinxmark_enable': True,
 #             'sphinxmark_div': 'default',
+#             'sphinxmark_border': None,
 #             'sphinxmark_repeat': True,
+#             'sphinxmark_fixed': False,
 #             'sphinxmark_image': 'default',
 #             'sphinxmark_text': 'default',
 #             'sphinxmark_text_color': (255, 0, 0),
 #             'sphinxmark_text_size': 100,
-#             'sphinxmark_text_opacity': 20
-#             'sphinxmark_text_spacing': 400}
+#             'sphinxmark_text_opacity': 20,
+#             'sphinxmark_text_spacing': 400,
+#             'sphinxmark_text_rotation': 0}
 
 htmlfile = 'index.html'
 htmlresult = ('<link rel="stylesheet" ' +
@@ -29,18 +32,49 @@ def test_defaults():
     app.builder.build_all()
     assert app.config.sphinxmark_div == 'default'
     assert app.config.sphinxmark_repeat is True
+    assert app.config.sphinxmark_border is None
+    assert app.config.sphinxmark_fixed is False
     assert app.config.sphinxmark_image == 'default'
     assert app.config.sphinxmark_text == 'default'
     assert app.config.sphinxmark_text_color == (255, 0, 0)
     assert app.config.sphinxmark_text_size == 100
     assert app.config.sphinxmark_text_opacity == 20
     assert app.config.sphinxmark_text_spacing == 400
+    assert app.config.sphinxmark_text_rotation == 0
 
     html = (app.outdir / htmlfile).read_text()
     assert htmlresult in html
 
     css = (app.outdir / cssfile).read_text()
     assert ('url("watermark-draft.png")') in css
+
+
+def test_div():
+    """Test div."""
+    app = MakeApp(srcdir='tests/marktest', copy_srcdir_to_tmpdir=True,
+                  confoverrides={'sphinxmark_div': 'body-test'})
+    app.builder.build_all()
+    assert app.config.sphinxmark_div == 'body-test'
+
+    html = (app.outdir / htmlfile).read_text()
+    assert htmlresult in html
+
+    css = (app.outdir / cssfile).read_text()
+    assert ('div.body-test') in css
+
+
+def test_border():
+    """Test border."""
+    app = MakeApp(srcdir='tests/marktest', copy_srcdir_to_tmpdir=True,
+                  confoverrides={'sphinxmark_border': 'left'})
+    app.builder.build_all()
+    assert app.config.sphinxmark_border == 'left'
+
+    html = (app.outdir / htmlfile).read_text()
+    assert htmlresult in html
+
+    css = (app.outdir / cssfile).read_text()
+    assert ('border-left') in css
 
 
 def test_repeat():
@@ -70,20 +104,18 @@ def test_no_repeat():
     assert ('background-repeat: no-repeat !important;') in css
 
 
-def test_textmark():
-    """Test textmark."""
+def test_fixed():
+    """Test fixed."""
     app = MakeApp(srcdir='tests/marktest', copy_srcdir_to_tmpdir=True,
-                  confoverrides={'sphinxmark_image': 'text',
-                                 'sphinxmark_text': 'Mitaka'})
+                  confoverrides={'sphinxmark_fixed': True})
     app.builder.build_all()
-    assert app.config.sphinxmark_image == 'text'
-    assert app.config.sphinxmark_text == 'Mitaka'
+    assert app.config.sphinxmark_fixed is True
 
     html = (app.outdir / htmlfile).read_text()
     assert htmlresult in html
 
     css = (app.outdir / cssfile).read_text()
-    assert ('url("textmark_Mitaka.png")') in css
+    assert ('background-attachment: fixed') in css
 
 
 def test_image():
@@ -102,7 +134,7 @@ def test_image():
     assert cssresult in css
 
 
-@xfail(raises=IOError)
+@xfail(raises=TypeError)
 def test_imagefail():
     """Test image not found."""
     # ------------------ THIS SHOULD FAIL ------------------
@@ -118,6 +150,22 @@ def test_imagefail():
     css = (app.outdir / cssfile).read_text()
     cssresult = 'url("%s")' % image
     assert cssresult in css
+
+
+def test_textmark():
+    """Test textmark."""
+    app = MakeApp(srcdir='tests/marktest', copy_srcdir_to_tmpdir=True,
+                  confoverrides={'sphinxmark_image': 'text',
+                                 'sphinxmark_text': 'Mitaka'})
+    app.builder.build_all()
+    assert app.config.sphinxmark_image == 'text'
+    assert app.config.sphinxmark_text == 'Mitaka'
+
+    html = (app.outdir / htmlfile).read_text()
+    assert htmlresult in html
+
+    css = (app.outdir / cssfile).read_text()
+    assert ('url("textmark_Mitaka.png")') in css
 
 
 def test_static():
@@ -139,7 +187,7 @@ def test_static():
     assert cssresult in css
 
 
-@xfail(raises=IOError)
+@xfail(raises=TypeError)
 def test_staticfail():
     """Test static not found."""
     # ------------------ THIS SHOULD FAIL ------------------
@@ -158,20 +206,6 @@ def test_staticfail():
     css = (app.outdir / cssfile).read_text()
     cssresult = 'url("%s")' % image
     assert cssresult in css
-
-
-def test_div():
-    """Test div."""
-    app = MakeApp(srcdir='tests/marktest', copy_srcdir_to_tmpdir=True,
-                  confoverrides={'sphinxmark_div': 'body-test'})
-    app.builder.build_all()
-    assert app.config.sphinxmark_div == 'body-test'
-
-    html = (app.outdir / htmlfile).read_text()
-    assert htmlresult in html
-
-    css = (app.outdir / cssfile).read_text()
-    assert ('div.body-test') in css
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Left or right border can be used for watermark.
Add fixed image option.
Add text rotation option.

Closes #14