### PR TITLE
Allow any Pillow version < 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ isort
 openstackdocstheme
 pep8-naming
 pep257
-Pillow<=3.4.1
+Pillow<3.5
 pyenchant
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
 
     install_requires=[
         'bottle<=0.12.10',
-        'Pillow<=3.4.1',
+        'Pillow<3.5',
     ],
 )


### PR DESCRIPTION
Recently Pillow 3.4.2 was released, which however conflicts with the
install requirements from sphinxmark.