### PR TITLE
Add sphinxmark_text_width config option

### DIFF
--- a/doc/options.rst
+++ b/doc/options.rst
@@ -81,6 +81,18 @@ sphinxmark_text_size (int)
 
      ``sphinxmark_text_size = 100``
 
+sphinxmark_text_width (int)
+   - Width of transparent box containing text specified in ``sphinxmark_text``
+   - If a large ``sphinxmark_text_size`` is specified, or the
+     ``sphinxmark_text`` string is long, you may need to set this option
+     to a number higher than the default for the entire string to display. Note
+     that the text will be cut off at the edge of the containing CSS div
+     regardless of the ``sphinxmark_text_width`` setting.
+   - Default = 1000
+   - Example:
+
+      ``sphinxmark_text_width = 1000``
+
 sphinxmark_text_color (tuple)
    - RGB color code for text specified in ``sphinxmark_text``.
    - Default = (255, 0, 0)

--- a/doc/relnotes.rst
+++ b/doc/relnotes.rst
@@ -5,6 +5,8 @@ Release Notes
 Release 0.1.17
 ~~~~~~~~~~~~~~
 
-- Remove Pillow version requirement.
-- Remove Bottle version requirement.
+- Add sphinxmark_text_width option and increase default width. (`#22
+  <https://github.com/kallimachos/sphinxmark/issues/22>`_)
+- Remove Pillow and Bottle version requirements. (`#23
+  <https://github.com/kallimachos/sphinxmark/issues/23>`_)
 - Add Release Notes and restructure documentation.

--- a/sphinxmark/__init__.py
+++ b/sphinxmark/__init__.py
@@ -65,7 +65,7 @@ def createimage(app, srcdir, buildpath):
     text = app.config.sphinxmark_text
 
     # draw transparent background
-    width = 400
+    width = app.config.sphinxmark_text_width
     height = app.config.sphinxmark_text_spacing
     img = Image.new('RGBA', (width, height), (255, 255, 255, 0))
     d = ImageDraw.Draw(img)
@@ -171,6 +171,7 @@ def setup(app):
         app.add_config_value('sphinxmark_text', 'default', 'html')
         app.add_config_value('sphinxmark_text_color', (255, 0, 0), 'html')
         app.add_config_value('sphinxmark_text_size', 100, 'html')
+        app.add_config_value('sphinxmark_text_width', 1000, 'html')
         app.add_config_value('sphinxmark_text_opacity', 20, 'html')
         app.add_config_value('sphinxmark_text_spacing', 400, 'html')
         app.add_config_value('sphinxmark_text_rotation', 0, 'html')

--- a/tests/marktest/conf.py
+++ b/tests/marktest/conf.py
@@ -70,6 +70,7 @@ sphinxmark_enable = True
 # sphinxmark_text = 'Mitaka'
 # sphinxmark_text_color = (255, 0, 0)
 # sphinxmark_text_size = 100
+# sphinxmark_text_width = 1000
 # sphinxmark_text_opacity = 50
 # sphinxmark_text_spacing = 600
 # sphinxmark_text_rotation = 90

--- a/tests/test.py
+++ b/tests/test.py
@@ -16,6 +16,7 @@ xfail = mark.xfail
 #             'sphinxmark_text': 'default',
 #             'sphinxmark_text_color': (255, 0, 0),
 #             'sphinxmark_text_size': 100,
+#             'sphinxmark_text_width': 1000,
 #             'sphinxmark_text_opacity': 20,
 #             'sphinxmark_text_spacing': 400,
 #             'sphinxmark_text_rotation': 0}
@@ -38,6 +39,7 @@ def test_defaults():
     assert app.config.sphinxmark_text == 'default'
     assert app.config.sphinxmark_text_color == (255, 0, 0)
     assert app.config.sphinxmark_text_size == 100
+    assert app.config.sphinxmark_text_width == 1000
     assert app.config.sphinxmark_text_opacity == 20
     assert app.config.sphinxmark_text_spacing == 400
     assert app.config.sphinxmark_text_rotation == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.3
-envlist = doc, bashate, flake8, isort, pep257, py2, py3
+envlist = doc, bashate, flake8, isort, pep257, py27, py3
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Make text width configurable and increase the default
width to prevent text being cut off.

Issue #22