### PR TITLE
remove invalid argument to ImageDraw.text() method

### DIFF
--- a/sphinxmark/__init__.py
+++ b/sphinxmark/__init__.py
@@ -82,7 +82,7 @@ def createimage(app, srcdir, buildpath):
 
     # add text to image
     color = app.config.sphinxmark_text_color
-    d.text((x, y), text, font=font, fill=color, align="center")
+    d.text((x, y), text, font=font, fill=color)
 
     # set opacity
     img.putalpha(app.config.sphinxmark_text_opacity)


### PR DESCRIPTION
It doesn't look like ImageDraw.text() ever took an "align"
argument. Before Pillow 4.2.0, the extra argument was ignored. Now it is
being passed to the font's getmask2() method, which causes an exception
due to the unexpected argument. The relevant change in Pillow is commit
02d0bcbc6b97f39dde6ba7bc55f1d38be8422ecc.

This change removes the extraneous argument from the originating call to
avoid the exception.

Signed-off-by: Doug Hellmann <doug@doughellmann.com>